### PR TITLE
Enable HTTPS and reverse proxy for Go app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,18 +16,17 @@ services:
     image: nginx:latest
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - ./nginx/conf-prod:/etc/nginx/conf.d:ro
-      - ./nginx/certs:/etc/letsencrypt
-      - ./nginx/www:/var/www/certbot
+      - /etc/letsencrypt/live/femprocentoppetid.dk:/etc/letsencrypt/live/femprocentoppetid.dk
+      - /etc/letsencrypt/archive/femprocentoppetid.dk:/etc/letsencrypt/archive/femprocentoppetid.dk
     depends_on: # Sørger for at nginx først kører efter vores GO server
       - whoknows_variations
     restart: unless-stopped
     networks: 
       - appnet
 
-volumes:
-  appdata:
 
 networks:
   appnet:

--- a/nginx/conf-prod/default.conf
+++ b/nginx/conf-prod/default.conf
@@ -1,12 +1,25 @@
-server {
-    listen 80;
-    server_name localhost;
+events { }
 
-     location / {
-        proxy_pass http://whoknows_variations:8080;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+http {
+    server {
+        listen 80;
+        server_name femprocentoppetid.dk www.femprocentoppetid.dk;
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+        server_name femprocentoppetid.dk www.femprocentoppetid.dk;
+
+        ssl_certificate /etc/letsencrypt/live/femprocentoppetid.dk/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/femprocentoppetid.dk/privkey.pem;
+
+         location / {
+            proxy_pass http://whoknows_variations:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
     }
 }


### PR DESCRIPTION
## Commit Message

Enable HTTPS and reverse proxy for Go app

---

## Description

Added HTTPS support to the application using Nginx and Let's Encrypt certificates.  
Configured Nginx to redirect all HTTP traffic to HTTPS and set up a reverse proxy to forward requests to the `whoknows_variations` Go application container.  
Updated Docker Compose to expose port 443 and mount certificate volumes for SSL.

Fixes # (issue)

---

## Type of Change

Mark the relevant options with an "x".

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (changes that could affect existing functionality)
- [ ] Code cleanup or refactor
- [ ] Documentation update
- [ ] Other (please describe):

---

## Testing

Describe how you tested your changes.

- [x] Tested locally with `docker compose up` and verified HTTPS access
- [x] Verified that HTTP traffic is redirected to HTTPS
- [x] Verified that requests are correctly proxied to the Go app container
- [ ] Simulator tested
- [ ] Other (please specify):

---

## Notes for Reviewers

- Ensure that the Let's Encrypt certificates exist on the host under `/etc/letsencrypt/live/femprocentoppetid.dk/`.  
- Nginx container needs read access to the mounted certificate directories.  
- After certificate renewal, the Nginx container must be restarted to pick up the new certificates:  
```bash
docker-compose restart nginx

