### PR TITLE
Add Prometheus metrics endpoint

### DIFF
--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -1,147 +1,34 @@
 package main
 
 import (
-	"fmt"
-	"net/http"
-	"sort"
-	"strconv"
-	"strings"
-	"sync"
-	"time"
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-type prometheusLabels struct {
-	method string
-	path   string
-	status string
+var (
+	requestCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "http_requests_total",
+			Help: "Total number of HTTP requests.",
+		},
+		[]string{"method", "path", "status"},
+	)
+
+	requestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "http_request_duration_seconds",
+			Help:    "Duration of HTTP requests.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"method", "path", "status"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(requestCounter, requestDuration)
 }
 
-type histogram struct {
-	counts []uint64
-	sum    float64
-	count  uint64
-}
-
-type metricsRecorder struct {
-	mu      sync.Mutex
-	buckets []float64
-	counter map[prometheusLabels]uint64
-	timing  map[prometheusLabels]*histogram
-}
-
-var defaultMetrics = newMetricsRecorder()
-
-func newMetricsRecorder() *metricsRecorder {
-	return &metricsRecorder{
-		buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
-		counter: make(map[prometheusLabels]uint64),
-		timing:  make(map[prometheusLabels]*histogram),
-	}
-}
-
-func observeRequest(duration time.Duration, labels prometheusLabels) {
-	defaultMetrics.observe(duration, labels)
-}
-
-func (m *metricsRecorder) observe(duration time.Duration, labels prometheusLabels) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	m.counter[labels]++
-
-	hist, ok := m.timing[labels]
-	if !ok {
-		hist = &histogram{counts: make([]uint64, len(m.buckets))}
-		m.timing[labels] = hist
-	}
-
-	seconds := duration.Seconds()
-	hist.sum += seconds
-	hist.count++
-	for i, bound := range m.buckets {
-		if seconds <= bound {
-			hist.counts[i]++
-		}
-	}
-}
-
-func metricsHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "text/plain; version=0.0.4")
-	fmt.Fprint(w, defaultMetrics.render())
-}
-
-func (m *metricsRecorder) render() string {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	var builder strings.Builder
-
-	builder.WriteString("# HELP http_requests_total Total number of HTTP requests\n")
-	builder.WriteString("# TYPE http_requests_total counter\n")
-	for _, labels := range m.sortedCounterKeys() {
-		builder.WriteString(fmt.Sprintf("http_requests_total%s %d\n", formatCounterLabels(labels), m.counter[labels]))
-	}
-
-	builder.WriteString("# HELP http_request_duration_seconds Time taken to serve HTTP requests\n")
-	builder.WriteString("# TYPE http_request_duration_seconds histogram\n")
-	for _, labels := range m.sortedTimingKeys() {
-		hist := m.timing[labels]
-		for i, bound := range m.buckets {
-			builder.WriteString(fmt.Sprintf(
-				"http_request_duration_seconds_bucket%s %d\n",
-				formatHistogramLabels(labels, strconv.FormatFloat(bound, 'g', -1, 64)),
-				hist.counts[i],
-			))
-		}
-		builder.WriteString(fmt.Sprintf(
-			"http_request_duration_seconds_bucket%s %d\n",
-			formatHistogramLabels(labels, "+Inf"),
-			hist.count,
-		))
-		builder.WriteString(fmt.Sprintf("http_request_duration_seconds_sum%s %.6f\n", formatCounterLabels(labels), hist.sum))
-		builder.WriteString(fmt.Sprintf("http_request_duration_seconds_count%s %d\n", formatCounterLabels(labels), hist.count))
-	}
-
-	return builder.String()
-}
-
-func (m *metricsRecorder) sortedCounterKeys() []prometheusLabels {
-	keys := make([]prometheusLabels, 0, len(m.counter))
-	for k := range m.counter {
-		keys = append(keys, k)
-	}
-	sort.Slice(keys, func(i, j int) bool {
-		return labelKey(keys[i]) < labelKey(keys[j])
-	})
-	return keys
-}
-
-func (m *metricsRecorder) sortedTimingKeys() []prometheusLabels {
-	keys := make([]prometheusLabels, 0, len(m.timing))
-	for k := range m.timing {
-		keys = append(keys, k)
-	}
-	sort.Slice(keys, func(i, j int) bool {
-		return labelKey(keys[i]) < labelKey(keys[j])
-	})
-	return keys
-}
-
-func labelKey(label prometheusLabels) string {
-	return label.method + "|" + label.path + "|" + label.status
-}
-
-func formatCounterLabels(labels prometheusLabels) string {
-	return fmt.Sprintf("{method=\"%s\",path=\"%s\",status=\"%s\"}", escapeLabel(labels.method), escapeLabel(labels.path), escapeLabel(labels.status))
-}
-
-func formatHistogramLabels(labels prometheusLabels, bucket string) string {
-	return fmt.Sprintf("{le=\"%s\",method=\"%s\",path=\"%s\",status=\"%s\"}", escapeLabel(bucket), escapeLabel(labels.method), escapeLabel(labels.path), escapeLabel(labels.status))
-}
-
-func escapeLabel(value string) string {
-	value = strings.ReplaceAll(value, "\\", "\\\\")
-	value = strings.ReplaceAll(value, "\n", "\\n")
-	value = strings.ReplaceAll(value, "\"", "\\\"")
-	return value
+func metricsHandler() gin.HandlerFunc {
+	return gin.WrapH(promhttp.Handler())
 }

--- a/cmd/middleware.go
+++ b/cmd/middleware.go
@@ -19,8 +19,10 @@ func loggingMiddleware() gin.HandlerFunc {
 			path = c.Request.URL.Path
 		}
 
-		labels := prometheusLabels{method: c.Request.Method, path: path, status: fmt.Sprintf("%d", status)}
-		observeRequest(duration, labels)
+		labels := []string{c.Request.Method, path, fmt.Sprintf("%d", status)}
+		requestCounter.WithLabelValues(labels...).Inc()
+		requestDuration.WithLabelValues(labels...).Observe(duration.Seconds())
+
 		log.Printf("[REQ] %s %s -> %d (%v)", c.Request.Method, path, status, duration)
 	}
 }

--- a/cmd/router.go
+++ b/cmd/router.go
@@ -6,7 +6,7 @@ func newRouter() *gin.Engine {
 	router := gin.New()
 	router.Use(gin.Recovery(), loggingMiddleware())
 
-	router.GET("/metrics", gin.WrapF(metricsHandler))
+	router.GET("/metrics", metricsHandler())
 
 	api := router.Group("/api")
 	{

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,11 @@ module WHOKNOWS_VARIATIONS
 go 1.23.0
 
 require (
-	github.com/gin-gonic/gin v1.10.1
-	github.com/stretchr/testify v1.9.0
-	golang.org/x/crypto v0.35.0
-	modernc.org/sqlite v1.38.2
+        github.com/gin-gonic/gin v1.10.1
+        github.com/prometheus/client_golang v1.19.1
+        github.com/stretchr/testify v1.9.0
+        golang.org/x/crypto v0.35.0
+        modernc.org/sqlite v1.38.2
 )
 
 require (


### PR DESCRIPTION
## Summary
- record request counts and latency buckets for each route and status
- expose a Prometheus-compatible `/metrics` endpoint for scraping from Grafana/Prometheus

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69341b4f39b4832fa806579a60aebc44)